### PR TITLE
Improve background page detection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-const isExtensionContext = typeof chrome === 'object' && chrome && typeof chrome.runtime === 'object';
+const isExtensionContext = typeof chrome === 'object' && chrome && typeof chrome.extension === 'object';
 const isWeb = location.protocol.startsWith('http');
 
 export function isContentScript(): boolean {
@@ -6,8 +6,9 @@ export function isContentScript(): boolean {
 }
 
 export function isBackgroundPage(): boolean {
-	return isExtensionContext && !isWeb &&
-		location.pathname === '/_generated_background_page.html';
+	return isExtensionContext &&
+		chrome.extension.getBackgroundPage &&
+		chrome.extension.getBackgroundPage() === window;
 }
 
 export function isOptionsPage(): boolean {


### PR DESCRIPTION
Based on https://stackoverflow.com/questions/16267668/can-js-code-in-chrome-extension-detect-that-its-executed-as-content-script/44071698#44071698

This will make it work even if the background page is an HTML page instead of a JS page.