### PR TITLE
Use `globalThis` to shorten code

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
-const isExtensionContext = typeof chrome === 'object' && chrome && typeof chrome.extension === 'object';
-const globalWindow = typeof window === 'object' ? window : undefined;
-const isWeb = typeof location === 'object' && location.protocol.startsWith('http');
+const isExtensionContext = globalThis.chrome?.extension === 'object';
+const isWeb = globalThis.location?.protocol.startsWith('http');
 
 export function isContentScript(): boolean {
 	return isExtensionContext && isWeb;
@@ -9,7 +8,7 @@ export function isContentScript(): boolean {
 export function isBackgroundPage(): boolean {
 	return isExtensionContext && (
 		location.pathname === '/_generated_background_page.html' ||
-		chrome.extension?.getBackgroundPage?.() === globalWindow
+		chrome.extension?.getBackgroundPage?.() === globalThis
 	);
 }
 


### PR DESCRIPTION
Might be a breaking change.

Firefox 65+: January 29, 2019
Chrome 71+: December 4, 2018
Safari 12.1+: ~

… or maybe not