### PR TITLE
Add `isDevToolsPage`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -51,3 +51,18 @@ export const isOptionsPage = once((): boolean => {
 	const url = new URL(options_ui.page, location.origin);
 	return url.pathname === location.pathname;
 });
+
+/** Indicates whether the code is being run in a dev tools page. This only works if the current page’s URL matches the one specified in the extension's `manifest.json` `devtools_page` field. */
+export const isDevToolsPage = once((): boolean => {
+	if (!isExtensionContext() || !chrome.runtime.getManifest) {
+		return false;
+	}
+
+	const {devtools_page} = chrome.runtime.getManifest();
+	if (devtools_page !== 'string') {
+		return false;
+	}
+
+	const url = new URL(devtools_page, location.origin);
+	return url.pathname === location.pathname;
+});

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,10 @@ Returns a `boolean` that indicates whether the code is being run in a content sc
 
 Returns a `boolean` that indicates whether the code is being run in an options page. This only works if the current page’s URL matches the one specified in the extension's `manifest.json`.
 
+#### isDevToolsPage()
+
+Returns a `boolean`  that indicates whether the code is being run in a dev tools page. This only works if the current page’s URL matches the one specified in the extension's `manifest.json` `devtools_page` field.
+
 ## Testing
 
 The calls are automatically cached so, if you're using this in a test environment, import and call this function first to ensure that the environment is "detected" every time:


### PR DESCRIPTION
Part of https://github.com/fregante/webext-detect-page/issues/4

Problem: it detects `devtools_page` but not the panel within it. It probably needs an additional check for a generic `isDevTools`