### PR TITLE
Improve background detection (especially in service workers)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -107,7 +107,7 @@ export const isSafari = () => !isChrome() && globalThis.navigator?.userAgent.inc
 
 const contextNames = {
 	contentScript: isContentScript,
-	backgroundPage: isBackgroundPage,
+	background: isBackground,
 	options: isOptionsPage,
 	devToolsPage: isDevToolsPage,
 	extension: isExtensionContext,

--- a/index.ts
+++ b/index.ts
@@ -56,15 +56,23 @@ export const isBackground = (): boolean => isBackgroundPage() || isBackgroundWor
 export const isBackgroundPage = once((): boolean => {
 	const manifest = getManifest(2);
 
-	if (manifest && isCurrentPathname(manifest.background_page || manifest.background?.page)) {
+	if (
+		manifest
+		&& isCurrentPathname(manifest.background_page || manifest.background?.page)
+	) {
 		return true;
 	}
 
-	return Boolean(manifest?.background?.scripts && isCurrentPathname('/_generated_background_page.html'));
+	return Boolean(
+		manifest?.background?.scripts
+		&& isCurrentPathname('/_generated_background_page.html'),
+	);
 });
 
 /** Indicates whether the code is being run in a background worker */
-export const isBackgroundWorker = once((): boolean => isCurrentPathname(getManifest(3)?.background?.service_worker));
+export const isBackgroundWorker = once(
+	(): boolean => isCurrentPathname(getManifest(3)?.background?.service_worker),
+);
 
 /** Indicates whether the code is being run in an options page. This only works if the current page’s URL matches the one specified in the extension's `manifest.json` */
 export const isOptionsPage = once((): boolean => {

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,26 @@ export function disableWebextDetectPageCache(): void {
 	cache = false;
 }
 
+function isCurrentPathname(path?: string): boolean {
+	if (!path) {
+		return false;
+	}
+
+	try {
+		const {pathname} = new URL(path, location.origin);
+		return pathname === location.pathname;
+	} catch {
+		return false;
+	}
+}
+
+/** Internal utility just to get the right manifest type. Chrome seems to accept workers even on v2 */
+function getManifest(version: 2): chrome.runtime.ManifestV2 | void;
+function getManifest(version: 3): chrome.runtime.ManifestV3 | void;
+function getManifest(_version?: 2 | 3): chrome.runtime.Manifest | void {
+	return globalThis.chrome?.runtime?.getManifest?.();
+}
+
 function once(function_: () => boolean): () => boolean {
 	let result: boolean;
 	return () => {
@@ -29,13 +49,22 @@ export const isContentScript = once((): boolean =>
 	isExtensionContext() && isWebPage(),
 );
 
+/** Indicates whether the code is being run in a background context */
+export const isBackground = (): boolean => isBackgroundPage() || isBackgroundWorker();
+
 /** Indicates whether the code is being run in a background page */
-export const isBackgroundPage = once((): boolean =>
-	isExtensionContext() && (
-		location.pathname === '/_generated_background_page.html'
-		|| chrome.extension?.getBackgroundPage?.() === globalThis.window
-	),
-);
+export const isBackgroundPage = once((): boolean => {
+	const manifest = getManifest(2);
+
+	if (manifest && isCurrentPathname(manifest.background_page || manifest.background?.page)) {
+		return true;
+	}
+
+	return Boolean(manifest?.background?.scripts && isCurrentPathname('/_generated_background_page.html'));
+});
+
+/** Indicates whether the code is being run in a background worker */
+export const isBackgroundWorker = once((): boolean => isCurrentPathname(getManifest(3)?.background?.service_worker));
 
 /** Indicates whether the code is being run in an options page. This only works if the current page’s URL matches the one specified in the extension's `manifest.json` */
 export const isOptionsPage = once((): boolean => {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^2.0.0",
-		"@types/chrome": "0.0.161",
+		"@types/chrome": "^0.0.170",
 		"typescript": "^4.4.4",
 		"xo": "^0.45.0"
 	}

--- a/readme.md
+++ b/readme.md
@@ -47,9 +47,17 @@ Returns a `boolean` that indicates whether the code is being run on `http(s)://`
 
 Returns a `boolean` that indicates whether the code is being run in extension contexts that have access to the chrome API.
 
+#### isBackground()
+
+Returns a `boolean` that indicates whether the code is being run in a background page or background worker.
+
 #### isBackgroundPage()
 
-Returns a `boolean` that indicates whether the code is being run in a background page.
+Returns a `boolean` that indicates whether the code is being run in a background page (manifest v2).
+
+#### isBackgroundWorker()
+
+Returns a `boolean` that indicates whether the code is being run in a background worker (manifest v3).
 
 #### isContentScript()
 

--- a/readme.md
+++ b/readme.md
@@ -74,7 +74,7 @@ Returns a `boolean` if it matches the current browser. They are loose detections
 Returns the first matching context among those defined in `index.ts`, depending on the current context:
 
 - 'contentScript'
-- 'backgroundPage'
+- 'background'
 - 'options'
 - 'devToolsPage'
 - 'extension'

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ npm install webext-detect-page
 import {
 	isBackgroundPage,
 	isContentScript,
-	isOptionsPage
+	isOptionsPage,
 } from 'webext-detect-page';
 ```
 


### PR DESCRIPTION


`isBackgroundPage` was returning true even in any extension workers, by chance:

- `getBackgroundPage()` (undefined) `=== globalThis.window` (undefined) 🤭 

This PR:

- Adds isBackground (works on all types of background pages)
- Adds isBackgroundWorker
- Stops isBackgroundPage from reporting true in service workers
- Makes isBackgroundPage work with raw text instead of requesting the background `window` (which probably awoke background event pages)
- Updates getContextName to return `background` instead of `backgroundPage`

Fixes:

- https://github.com/fregante/webext-detect-page/issues/11